### PR TITLE
update link to CS19 website

### DIFF
--- a/Cool_Stars_21.html
+++ b/Cool_Stars_21.html
@@ -540,7 +540,7 @@ We are thrilled to announce that pre-registration is now <a href="https://docs.g
        <div class="c12 row">
 	 <ul class="listing">
 	   <li>CS 20 - <a href="http://coolstars20.cfa.harvard.edu/">Boston, USA, July 2018</a></li>
-	   <li>CS 19 - <a href="http://coolstars19.com/">Uppsala, Sweden, June 2016</a></li>
+	   <li>CS 19 - <a href="http://www.astro.uu.se/~cool19/">Uppsala, Sweden, June 2016</a></li>
 	   <li>CS 18 - <a href="http://www2.lowell.edu/workshops/coolstars18/">Flagstaff, USA, June 2014</a></li>
 	   <li>CS 17 - Barcelona, Spain, June 2012</li>
 	   <li>CS 16 - Seattle, USA, August 2010</li>

--- a/images/Cool_Stars_21.html
+++ b/images/Cool_Stars_21.html
@@ -511,7 +511,7 @@ We are thrilled to announce that pre-registration is now <a href="https://docs.g
        <div class="c12 row">
 	 <ul class="listing">
 	   <li>CS 20 - <a href="http://coolstars20.cfa.harvard.edu/">Boston, USA, July 2018</a></li>
-	   <li>CS 19 - <a href="http://coolstars19.com/">Uppsala, Sweden, June 2016</a></li>
+	   <li>CS 19 - <a href="http://www.astro.uu.se/~cool19/">Uppsala, Sweden, June 2016</a></li>
 	   <li>CS 18 - <a href="http://www2.lowell.edu/workshops/coolstars18/">Flagstaff, USA, June 2014</a></li>
 	   <li>CS 17 - Barcelona, Spain, June 2012</li>
 	   <li>CS 16 - Seattle, USA, August 2010</li>

--- a/images/index.html
+++ b/images/index.html
@@ -511,7 +511,7 @@ We are thrilled to announce that pre-registration is now <a href="https://docs.g
        <div class="c12 row">
 	 <ul class="listing">
 	   <li>CS 20 - <a href="http://coolstars20.cfa.harvard.edu/">Boston, USA, July 2018</a></li>
-	   <li>CS 19 - <a href="http://coolstars19.com/">Uppsala, Sweden, June 2016</a></li>
+	   <li>CS 19 - <a href="http://www.astro.uu.se/~cool19/">Uppsala, Sweden, June 2016</a></li>
 	   <li>CS 18 - <a href="http://www2.lowell.edu/workshops/coolstars18/">Flagstaff, USA, June 2014</a></li>
 	   <li>CS 17 - Barcelona, Spain, June 2012</li>
 	   <li>CS 16 - Seattle, USA, August 2010</li>

--- a/index.html
+++ b/index.html
@@ -628,7 +628,7 @@ We are thrilled to announce that pre-registration is now <a href="https://docs.g
        href="http://coolstars20.cfa.harvard.edu/cs20half/index.html" target="_blank">CS 20.5</a> - online,
        March 2021</li>
 	   <li><a href="http://coolstars20.cfa.harvard.edu/" target="_blank">CS 20</a> - Boston, USA, July 2018</li>
-	   <li><a href="http://coolstars19.com/" target="_blank">CS 19</a> - Uppsala, Sweden, June 2016</li>
+	   <li><a href="http://www.astro.uu.se/~cool19/" target="_blank">CS 19</a> - Uppsala, Sweden, June 2016</li>
 	   <li><a
        href="http://www2.lowell.edu/workshops/coolstars18/" target="_blank">CS 18</a> - Flagstaff, USA, June 2014</li>
 	   <li>CS 17 - Barcelona, Spain, June 2012</li>

--- a/pagesrc/index.html
+++ b/pagesrc/index.html
@@ -192,7 +192,7 @@
        <div class="c12 row">
 	 <ul class="listing">
 	   <li>CS 20 - <a href="http://coolstars20.cfa.harvard.edu/">Boston, USA, July 2018</a></li>
-	   <li>CS 19 - <a href="http://coolstars19.com/">Uppsala, Sweden, June 2016</a></li>
+	   <li>CS 19 - <a href="http://www.astro.uu.se/~cool19/">Uppsala, Sweden, June 2016</a></li>
 	   <li>CS 18 - <a href="http://www2.lowell.edu/workshops/coolstars18/">Flagstaff, USA, June 2014</a></li>
 	   <li>CS 17 - Barcelona, Spain, June 2012</li>
 	   <li>CS 16 - Seattle, USA, August 2010</li>

--- a/pagesrc/index.html~
+++ b/pagesrc/index.html~
@@ -146,7 +146,7 @@
        <div class="c12 row">
 	 <ul class="listing">
 	   <li>CS 20 - <a href="http://coolstars20.cfa.harvard.edu/">Boston, USA, July/August 2018</a></li>
-	   <li>CS 19 - <a href="http://coolstars19.com/">Uppsala, Sweden, June 2016</a></li>
+	   <li>CS 19 - <a href="http://www.astro.uu.se/~cool19/">Uppsala, Sweden, June 2016</a></li>
 	   <li>CS 18 - <a href="http://www2.lowell.edu/workshops/coolstars18/">Flagstaff, AZ, USA, June 2014</a></li>
 	   <li>CS 17 - Barcelona, SPAIN, June 2012</li>
 	   <li>CS 16 - Seattle, WA, USA, August 2010</li>


### PR DESCRIPTION
We have not renewed the domain coolstars19.com, it has now been bought by somebody else and hosting a completely different website.
I have updated all occurences of coolstars19.com to www.astro.uu.se/~cool19 where the CS19 webpage resides. 